### PR TITLE
Post-integration bugfixes

### DIFF
--- a/lib/lighthouse/matchers.rb
+++ b/lib/lighthouse/matchers.rb
@@ -24,7 +24,7 @@ module Lighthouse
       end
 
       def runner
-        @runner ||= Kernel.method(:system)
+        @runner ||= proc { |cmd| `#{cmd}` }
       end
 
       private

--- a/lib/lighthouse/matchers.rb
+++ b/lib/lighthouse/matchers.rb
@@ -20,7 +20,7 @@ module Lighthouse
       end
 
       def lighthouse_cli
-        @lighthouse_cli ||= lighthouse_cli
+        @lighthouse_cli ||= guess_lighthouse_cli
       end
 
       def runner

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -11,8 +11,7 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, score: nil|
     runner = Lighthouse::Matchers.runner
 
     url = target.respond_to?(:current_url) ? target.current_url : target
-    opts = "'#{url}' --quiet --output=json"
-    opts << " --port '#{port}'" if port
+    opts = "'#{url}' --quiet --output=json #{"--port=#{port}" if port}".strip
     cmd = Lighthouse::Matchers.lighthouse_cli
     output = runner.call("#{cmd} #{opts}")
     results = JSON.parse(output)


### PR DESCRIPTION
Some critical fixes following integration of this gem into an actual project.

Bugs fixed:

1. A system stack level error arising from `lighthouse_cli` calling itself, instead of the correct fallback method, `guess_lighthouse_cli`.
2. Avoid modifying a frozen string when setting up `lighthouse` CLI opts
3. Using `Kernel.system` was preferred because it was easy to set expectations against. `Kernel.system` does not assign the standard output as the return value though, so revert to normal backtick command wrapped in a Proc.