### PR TITLE
Issue #8: Allow Chrome flags to be specified by the client to allow launching in a containerized environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ All configuration keys are accessible against the `Lighthouse::Matchers` object.
   for the CLI. This setting can be used if the Lighthouse tool is installed in a non-standard location.
 * **`minimum_score`:** The default minimum score that audits must meet for the matcher to pass. 
   The default value of this configuration setting is '100' - e.g. audits must fully comply to pass.
+* **`chrome_flags`:** Any additional flags that should be passed to Chrome when Lighthouse launches a browser instance. As an example, running Lighthouse in Docker requires the normal headless Chrome flags (`--headless`, `--no-sandbox`) for Chrome to successfully start. Chrome flags can either be specified as an array (`["headless", "no-sandbox"]`) or as a string (`--headless --no-sandbox`).
 
 ## Compatibility
 

--- a/lib/lighthouse/audit_service.rb
+++ b/lib/lighthouse/audit_service.rb
@@ -1,6 +1,7 @@
-# frozen_string_literal: true
+# frozen_string_literal: false
 
 require 'json'
+require 'stringio'
 
 # Compares a url's actual score to the expected score.
 class AuditService
@@ -11,6 +12,7 @@ class AuditService
     @port = Lighthouse::Matchers.remote_debugging_port
     @runner = Lighthouse::Matchers.runner
     @cmd = Lighthouse::Matchers.lighthouse_cli
+    @chrome_flags = Lighthouse::Matchers.chrome_flags
   end
 
   def passing_score?
@@ -20,7 +22,12 @@ class AuditService
   private
 
   def opts
-    "'#{@url}' --quiet --output=json #{"--port=#{@port}" if @port}".strip
+    "'#{@url}'".tap do |builder|
+      builder << ' --quiet'
+      builder << ' --output=json'
+      builder << " --port=#{@port}" if @port
+      builder << " --chrome-flags='#{@chrome_flags}'" if @chrome_flags
+    end.strip
   end
 
   def output

--- a/lib/lighthouse/matchers.rb
+++ b/lib/lighthouse/matchers.rb
@@ -2,17 +2,18 @@
 
 require 'lighthouse/matchers/version'
 
+##
+# Defines configuration and behaviours that are shared across the entire
+# Lighthouse::Matchers namespace
 module Lighthouse
-  ##
-  # Defines configuration and behaviours that are shared across the entire
-  # Lighthouse::Matchers namespace
-  module Matchers
+  module Matchers # rubocop:disable Style/Documentation
     class Error < StandardError; end
     class << self
       attr_writer :minimum_score,
                   :remote_debugging_port,
                   :lighthouse_cli,
-                  :runner
+                  :runner,
+                  :chrome_flags
       attr_reader :remote_debugging_port
 
       def minimum_score
@@ -25,6 +26,13 @@ module Lighthouse
 
       def runner
         @runner ||= proc { |cmd| `#{cmd}` }
+      end
+
+      def chrome_flags
+        return unless @chrome_flags
+        return @chrome_flags unless @chrome_flags.is_a?(Array)
+
+        @chrome_flags.map { |f| "--#{f}" }.join(' ')
       end
 
       private

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -83,6 +83,36 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
     end
   end
 
+  context 'with Chrome flags specified' do
+    context 'as a string' do
+      before { Lighthouse::Matchers.chrome_flags = '--headless --no-sandbox' }
+
+      it 'executes the expected command' do
+        command = expected_command + " --chrome-flags='--headless --no-sandbox'"
+
+        expect(runner).to receive(:call)
+          .with(command)
+          .and_return(response_fixture(:performance))
+
+        expect(example_url).to pass_lighthouse_audit(:performance)
+      end
+    end
+
+    context 'as an array' do
+      before { Lighthouse::Matchers.chrome_flags = %w[headless no-sandbox] }
+
+      it 'executes the expected command' do
+        command = expected_command + " --chrome-flags='--headless --no-sandbox'"
+
+        expect(runner).to receive(:call)
+          .with(command)
+          .and_return(response_fixture(:performance))
+
+        expect(example_url).to pass_lighthouse_audit(:performance)
+      end
+    end
+  end
+
   private
 
   def stub_command(cmd, result)


### PR DESCRIPTION
Adds a configuration hook to specify Chrome flags. These can be specified as an Array: `%w[headless no-sandbox]`, or as a string `--no-sandbox --headless`, or can be left blank.

This patch is necessary because running Chrome in a Docker container requires flags to be passed - specifically, the process must be run headlessly and with the no-sandbox option set. Because Lighthouse launches it's own instance of Chrome with it's own flags, we need to have the ability to customise how Chrome will be launched.

I expect that the Selenium webdriver options object can be passed to this config hook so that Lighthouse Matchers can inherit the Chrome flags that Selenium would use to launch the browser, leading to a consistent test environment.