### PR TITLE
Add lighthouse additional cli option

### DIFF
--- a/lib/lighthouse/audit_service.rb
+++ b/lib/lighthouse/audit_service.rb
@@ -13,10 +13,15 @@ class AuditService
     @runner = Lighthouse::Matchers.runner
     @cmd = Lighthouse::Matchers.lighthouse_cli
     @chrome_flags = Lighthouse::Matchers.chrome_flags
+    @lighthouse_options = Lighthouse::Matchers.lighthouse_options
   end
 
   def passing_score?
     measured_score >= @score
+  end
+
+  def measured_score
+    results.dig('categories', @audit.to_s, 'score') * 100
   end
 
   private
@@ -27,6 +32,7 @@ class AuditService
       builder << ' --output=json'
       builder << " --port=#{@port}" if @port
       builder << " --chrome-flags='#{@chrome_flags}'" if @chrome_flags
+      builder << " #{@lighthouse_options}" if @lighthouse_options
     end.strip
   end
 
@@ -36,9 +42,5 @@ class AuditService
 
   def results
     JSON.parse(output)
-  end
-
-  def measured_score
-    results.dig('categories', @audit.to_s, 'score') * 100
   end
 end

--- a/lib/lighthouse/matchers.rb
+++ b/lib/lighthouse/matchers.rb
@@ -13,6 +13,7 @@ module Lighthouse
                   :remote_debugging_port,
                   :lighthouse_cli,
                   :runner,
+                  :lighthouse_options,
                   :chrome_flags
       attr_reader :remote_debugging_port
 
@@ -26,6 +27,13 @@ module Lighthouse
 
       def runner
         @runner ||= proc { |cmd| `#{cmd}` }
+      end
+
+      def lighthouse_options
+        return unless @lighthouse_options
+        return @lighthouse_options unless @lighthouse_options.is_a?(Array)
+
+        @lighthouse_options.map { |f| "--#{f}" }.join(' ')
       end
 
       def chrome_flags

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -9,13 +9,14 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, score: nil|
   score ||= Lighthouse::Matchers.minimum_score
 
   match do |target|
-    AuditService.new(url(target), audit, score).passing_score?
+    @audit_service = AuditService.new(url(target), audit, score)
+    @audit_service.passing_score?
   end
 
   failure_message do |target|
     <<~FAIL
       expected #{url(target)} to pass Lighthouse #{audit} audit
-      with a minimum score of #{score}
+      with a minimum score of #{score}, current score is #{@audit_service.measured_score.to_i}
     FAIL
   end
 

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -67,7 +67,8 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
         expect do
           expect(example_url).to pass_lighthouse_audit(audit)
         end.to raise_error("expected #{example_url} to pass Lighthouse #{audit} audit\n"\
-          "with a minimum score of 100\n")
+                           "with a minimum score of 100, current score is #{score}\n")
+
       end
     end
   end
@@ -103,6 +104,38 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
 
       it 'executes the expected command' do
         command = expected_command + " --chrome-flags='--headless --no-sandbox'"
+
+        expect(runner).to receive(:call)
+          .with(command)
+          .and_return(response_fixture(:performance))
+
+        expect(example_url).to pass_lighthouse_audit(:performance)
+      end
+    end
+  end
+
+  context 'with Lighthouse Options specified' do
+    before { Lighthouse::Matchers.chrome_flags = nil }
+
+    context 'as a string' do
+      before { Lighthouse::Matchers.lighthouse_options = '--throttling-method=provided --emulated-form-factor=desktop' }
+
+      it 'executes the expected command' do
+        command = expected_command + " --throttling-method=provided --emulated-form-factor=desktop"
+
+        expect(runner).to receive(:call)
+          .with(command)
+          .and_return(response_fixture(:performance))
+
+        expect(example_url).to pass_lighthouse_audit(:performance)
+      end
+    end
+
+    context 'as an array' do
+      before { Lighthouse::Matchers.lighthouse_options = %w[throttling-method=provided emulated-form-factor=desktop] }
+
+      it 'executes the expected command' do
+        command = expected_command + " --throttling-method=provided --emulated-form-factor=desktop"
 
         expect(runner).to receive(:call)
           .with(command)

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -68,7 +68,6 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
           expect(example_url).to pass_lighthouse_audit(audit)
         end.to raise_error("expected #{example_url} to pass Lighthouse #{audit} audit\n"\
                            "with a minimum score of 100, current score is #{score}\n")
-
       end
     end
   end
@@ -118,10 +117,10 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
     before { Lighthouse::Matchers.chrome_flags = nil }
 
     context 'as a string' do
-      before { Lighthouse::Matchers.lighthouse_options = '--throttling-method=provided --emulated-form-factor=desktop' }
+      before { Lighthouse::Matchers.lighthouse_options = '--throttling-method=provided' }
 
       it 'executes the expected command' do
-        command = expected_command + " --throttling-method=provided --emulated-form-factor=desktop"
+        command = expected_command + " --throttling-method=provided"
 
         expect(runner).to receive(:call)
           .with(command)
@@ -132,10 +131,10 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
     end
 
     context 'as an array' do
-      before { Lighthouse::Matchers.lighthouse_options = %w[throttling-method=provided emulated-form-factor=desktop] }
+      before { Lighthouse::Matchers.lighthouse_options = %w[emulated-form-factor=desktop] }
 
       it 'executes the expected command' do
-        command = expected_command + " --throttling-method=provided --emulated-form-factor=desktop"
+        command = expected_command + " --emulated-form-factor=desktop"
 
         expect(runner).to receive(:call)
           .with(command)

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -120,7 +120,7 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
       before { Lighthouse::Matchers.lighthouse_options = '--throttling-method=provided' }
 
       it 'executes the expected command' do
-        command = expected_command + " --throttling-method=provided"
+        command = expected_command + ' --throttling-method=provided'
 
         expect(runner).to receive(:call)
           .with(command)
@@ -134,7 +134,7 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
       before { Lighthouse::Matchers.lighthouse_options = %w[emulated-form-factor=desktop] }
 
       it 'executes the expected command' do
-        command = expected_command + " --emulated-form-factor=desktop"
+        command = expected_command + ' --emulated-form-factor=desktop'
 
         expect(runner).to receive(:call)
           .with(command)


### PR DESCRIPTION
Wonderful work. The gem really helpful for my project but I would like to add ability to add additionals command-line options to this gem:
Use case on this will be adding `emulated-form-factor` or `throttling-method` 
Feel free to let me know any feedback or input since this my first time contributing.