### PR TITLE
Add Ruby 3.0.x to the Travis build matrix and fix some Ruby 3.0 issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ language: ruby
 addons:
   chrome: stable
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4
+  - 2.5
+  - 2.6
+  - 3.0
 cache: bundler
 before_install:
   - . $HOME/.nvm/nvm.sh

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -36,6 +36,7 @@ GEM
       unicode-display_width (>= 1.4.0, < 1.7)
     ruby-progressbar (1.10.0)
     unicode-display_width (1.6.0)
+    webrick (1.7.0)
 
 PLATFORMS
   ruby
@@ -46,6 +47,7 @@ DEPENDENCIES
   rake (~> 13.0)
   rspec (~> 3.0)
   rubocop
+  webrick
 
 BUNDLED WITH
-   2.0.2
+   2.2.32

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -5,8 +5,8 @@ require 'lighthouse/matchers'
 require 'lighthouse/audit_service'
 require 'json'
 
-RSpec::Matchers.define :pass_lighthouse_audit do |audit, score: nil|
-  score ||= Lighthouse::Matchers.minimum_score
+RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
+  score ||= args.fetch(:score, Lighthouse::Matchers.minimum_score)
 
   match do |target|
     AuditService.new(url(target), audit, score).passing_score?

--- a/lighthouse-matchers.gemspec
+++ b/lighthouse-matchers.gemspec
@@ -40,4 +40,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency 'rake', '~> 13.0'
   spec.add_development_dependency 'rspec', '~> 3.0'
   spec.add_development_dependency 'rubocop'
+  spec.add_development_dependency 'webrick'
 end


### PR DESCRIPTION
1. kwargs are not getting passed to RSpec properly. Fix: treat incoming args, if any, as a hash
2. Webrick is no longer part of the std library, because it shouldn't be used in production. Fix: Add a gem dependency.