### PR TITLE
ci: run linting and tests in different jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,17 @@ permissions:
   contents: read # to fetch code (actions/checkout)
 
 jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        persist-credentials: false
+    - uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: '3.1'
+        bundler-cache: true
+    - run: bundle exec rubocop
   test:
     runs-on: ubuntu-latest
     strategy:
@@ -40,6 +51,6 @@ jobs:
       with:
         cache: 'npm'
     - run: npm ci
-    - run: npm test
+    - run: bundle exec rake spec
       env:
         CI_CHROME_FLAGS: "--headless"

--- a/bin/ci-run
+++ b/bin/ci-run
@@ -1,6 +1,0 @@
-#!/usr/bin/env bash
-
-set -e
-
-bundle exec rake spec
-bundle exec rubocop

--- a/package.json
+++ b/package.json
@@ -6,9 +6,6 @@
   "directories": {
     "lib": "lib"
   },
-  "scripts": {
-    "test": "bin/ci-run"
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/ackama/lighthouse-matchers.git"


### PR DESCRIPTION
This splits our CI up into multiple jobs which is both faster and means we can test against Ruby 3.3 as the version of Rubocop we're using doesn't support that