### PR TITLE
feat: print run warnings from Lighthouse

### DIFF
--- a/lib/lighthouse/audit_service.rb
+++ b/lib/lighthouse/audit_service.rb
@@ -23,6 +23,10 @@ class AuditService
     results.dig('categories', @audit.to_s, 'score') * 100
   end
 
+  def run_warnings
+    results['runWarnings']
+  end
+
   private
 
   def opts
@@ -40,6 +44,6 @@ class AuditService
   end
 
   def results
-    JSON.parse(output)
+    @results ||= JSON.parse(output)
   end
 end

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -12,7 +12,9 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
     audit_service = AuditService.new(url(target), audit, score)
 
     audit_service.run_warnings.each do |warning|
-      RSpec.configuration.reporter.message(warning)
+      RSpec.configuration.reporter.message(
+        "#{RSpec.current_example.location}: #{warning}"
+      )
     end
 
     @measured_score = audit_service.measured_score

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
 
     audit_service.run_warnings.each do |warning|
       RSpec.configuration.reporter.message(
-        "#{RSpec.current_example.location}: #{warning}"
+        "#{RSpec.current_example.location}: [lighthouse] #{warning}"
       )
     end
 

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -11,6 +11,10 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
   match do |target|
     audit_service = AuditService.new(url(target), audit, score)
 
+    audit_service.run_warnings.each do |warning|
+      RSpec.configuration.reporter.message(warning)
+    end
+
     @measured_score = audit_service.measured_score
 
     audit_service.passing_score?

--- a/spec/lighthouse/audit_service_spec.rb
+++ b/spec/lighthouse/audit_service_spec.rb
@@ -38,6 +38,15 @@ RSpec.describe AuditService do
     end
   end
 
+  describe '#run_warnings' do
+    it 'returns the value of runWarnings from the results' do
+      stub_command(response_fixture)
+      expect(subject.run_warnings).to eq [
+        'The page may not be loading as expected because your test URL (http://127.0.0.1:35403/) was redirected to http://127.0.0.1:35403/users/sign_in. Try testing the second URL directly.' # rubocop:disable Layout/LineLength
+      ]
+    end
+  end
+
   private
 
   def stub_command(result)
@@ -48,6 +57,11 @@ RSpec.describe AuditService do
   end
 
   def response_fixture(result_score = score)
-    JSON.generate(categories: { audit => { score: result_score / 100.0 } })
+    JSON.generate(
+      categories: { audit => { score: result_score / 100.0 } },
+      runWarnings: [
+        'The page may not be loading as expected because your test URL (http://127.0.0.1:35403/) was redirected to http://127.0.0.1:35403/users/sign_in. Try testing the second URL directly.' # rubocop:disable Layout/LineLength
+      ]
+    )
   end
 end

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -132,6 +132,9 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
   end
 
   def response_fixture(audit, score = 100)
-    JSON.generate(categories: { audit => { score: score / 100.0 } })
+    JSON.generate(
+      categories: { audit => { score: score / 100.0 } },
+      runWarnings: []
+    )
   end
 end

--- a/spec/lighthouse/matchers/rspec_spec.rb
+++ b/spec/lighthouse/matchers/rspec_spec.rb
@@ -51,7 +51,9 @@ RSpec.describe 'pass_lighthouse_audit matcher' do
 
       allow(fake_audit_service).to receive(:passing_score?).and_return(true)
       allow(fake_audit_service).to receive(:measured_score).and_return(100)
+      allow(fake_audit_service).to receive(:run_warnings).and_return([])
 
+      expect(AuditService).to receive_message_chain(:new, :run_warnings)
       expect(AuditService).to receive_message_chain(:new, :passing_score?)
       expect(example_url).to pass_lighthouse_audit(audit, score: score)
     end


### PR DESCRIPTION
I've not added any tests for the matcher itself because this is calling real RSpec code so the warnings get actually printed and I'm not sure how safe it is to try and spy or mock anything from RSpec - I couldn't actually find a lot of guidance on this so very open to thoughts from those with more custom-matcher and gem experiences 😄

I have also for now chosen to assume `runWarnings` always exists since it will be very easy to switch to a `fetch` later if needed and this way we should end up hearing e.g. if this property gets renamed.

This is an example of the output:

```
./spec/system/home_feature_spec.rb:26: [lighthouse] The page may not be loading as expected because your test URL (http://127.0.0.1:35403/) was redirected to http://127.0.0.1:35403/users/sign_in. Try testing the second URL directly.
```

Resolves #53