### PR TITLE
feat: raise an explicit error when the audit category is not found

### DIFF
--- a/lib/lighthouse/audit_service.rb
+++ b/lib/lighthouse/audit_service.rb
@@ -5,6 +5,8 @@ require 'stringio'
 
 # Compares a url's actual score to the expected score.
 class AuditService
+  class Error < StandardError; end
+
   def initialize(url, audit, score)
     @url = url
     @audit = audit
@@ -20,10 +22,20 @@ class AuditService
   end
 
   def measured_score
-    results.dig('categories', @audit.to_s, 'score') * 100
+    category['score'] * 100
   end
 
   private
+
+  def category
+    category = results.dig('categories', @audit.to_s)
+
+    if category.nil?
+      raise Error, "Category '#{@audit}' not found in Lighthouse results - maybe it was removed?"
+    end
+
+    category
+  end
 
   def opts
     "'#{@url}'".tap do |builder|

--- a/spec/lighthouse/audit_service_spec.rb
+++ b/spec/lighthouse/audit_service_spec.rb
@@ -36,6 +36,35 @@ RSpec.describe AuditService do
         expect(subject.passing_score?).to eq true
       end
     end
+
+    context 'when the category is not found' do
+      it 'raises an error' do
+        stub_command(JSON.generate(categories: {}))
+        expect { subject.measured_score }.to raise_error(
+          AuditService::Error,
+          "Category '#{audit}' not found in Lighthouse results - maybe it was removed?"
+        )
+      end
+    end
+  end
+
+  describe '#measured_score' do
+    context 'when the category does exist' do
+      it 'returns the score as a percentage' do
+        stub_command(response_fixture)
+        expect(subject.measured_score).to eq score
+      end
+    end
+
+    context 'when the category is not found' do
+      it 'raises an error' do
+        stub_command(JSON.generate(categories: {}))
+        expect { subject.measured_score }.to raise_error(
+          AuditService::Error,
+          "Category '#{audit}' not found in Lighthouse results - maybe it was removed?"
+        )
+      end
+    end
   end
 
   private


### PR DESCRIPTION
Since Lighthouse currently does not actually validate the audit/category you specific, it's possible for us to get a 'successful' run without the expected category resulting in a raw error about not being able to multiple `nil` by 100.

To make it easier to debug, this has us raise an explicit error in this situation so the downstream user knows its an issue with their setup rather than a bug with us - note in particular this caught us out as Lighthouse recently removed the `pwa` audit category which we were checking in one of our applications.

Resolves #54