### PR TITLE
ci: setup automatic publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,30 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v*
+
+permissions:
+  contents: read # to fetch code (actions/checkout)
+
+jobs:
+  push:
+    permissions:
+      contents: write
+      id-token: write
+    if: github.repository == 'ackama/lighthouse-matchers'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@v2
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.2'
+          bundler-cache: true
+      - uses: rubygems/release-gem@v1

--- a/README.md
+++ b/README.md
@@ -121,6 +121,12 @@ for detailed instructions.
 
 This gem endeavours to follow Semantic Versioning 2.0 as defined at https://semver.org/.
 
+## Releasing
+
+Releases are done automatically by GitHub Actions when a new tag is pushed to the repository.
+
+To release a new version, create a pull request updating the "Unreleased" section of `CHANGELOG.md` file to reflect the upcoming version and expected release date, and to update the version number in `lib/lighthouse/matchers/version.rb`. Once the pull request is merged, create a new tag in the format `vX.Y.Z`, which will trigger GitHub Actions to publish the new version to RubyGems.
+
 ## License
 
 lighthouse-matchers is copyright © 2019 Ackama Group Ltd.


### PR DESCRIPTION
This sets up automatic publishing based on [this guide](https://guides.rubygems.org/trusted-publishing/adding-a-publisher/) - the workflow itself is based off [this example](https://github.com/segiddins/rubygems-await/blob/main/.github/workflows/push_gem.yml).

For now I've decided to keep the workflow light rather than e.g. run tests or linting since this is the first time we've automated gem publishing and it's unlikely we'll actually do a lot of releases so I want to make it as easy to release a new version.

I have left `rubygems_mfa_required` in the gemspec set to `true` as while the docs don't seem to explicitly say that doesn't apply to OIDC-based publishing, the `rubygems-await` codebase (which is using this workflow) does also have it enabled so I'm assuming its fine

Resolves #23