### PR TITLE
feat: write audit results to disk on failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Write audit results to disk on failure so they can be viewed using the browser viewer ([#68](https://github.com/ackama/lighthouse-matchers/pull/68))
+
 ### Changed
 - Prefix warnings with the full example description ([#69](https://github.com/ackama/lighthouse-matchers/pull/69))
 

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ All configuration keys are accessible against the `Lighthouse::Matchers` object.
 * **`minimum_score`:** The default minimum score that audits must meet for the matcher to pass.
   The default value of this configuration setting is '100' - e.g. audits must fully comply to pass.
 * **`chrome_flags`:** Any additional flags that should be passed to Chrome when Lighthouse launches a browser instance. As an example, running Lighthouse in Docker requires the normal headless Chrome flags (`--headless`, `--no-sandbox`) for Chrome to successfully start. Chrome flags can either be specified as an array (`["headless", "no-sandbox"]`) or as a string (`--headless --no-sandbox`).
+* **`results_directory`:** Directory to write lighthouse results on failure
+  * Defaults to `<RSpec.configuration.default_path>/lighthouse` if `RSpec` is defined, otherwise a temporary directory prefixed with `lighthouse-matchers-`
+  * For Rails applications, we recommend setting this to `Rails.root.join('/tmp/lighthouse')` in your `rails_helper.rb`
 
 ## Compatibility
 

--- a/lib/lighthouse/audit_service.rb
+++ b/lib/lighthouse/audit_service.rb
@@ -29,6 +29,10 @@ class AuditService
     results['runWarnings']
   end
 
+  def results
+    @results ||= JSON.parse(output)
+  end
+
   private
 
   def category
@@ -53,9 +57,5 @@ class AuditService
 
   def output
     @output ||= @runner.call("#{@cmd} #{opts}")
-  end
-
-  def results
-    @results ||= JSON.parse(output)
   end
 end

--- a/lib/lighthouse/matchers.rb
+++ b/lib/lighthouse/matchers.rb
@@ -9,7 +9,7 @@ module Lighthouse
   module Matchers # rubocop:disable Style/Documentation
     class Error < StandardError; end
     class << self
-      attr_writer :minimum_score, :lighthouse_cli, :runner, :chrome_flags
+      attr_writer :minimum_score, :lighthouse_cli, :runner, :chrome_flags, :results_directory
       attr_accessor :remote_debugging_port
 
       def minimum_score
@@ -29,6 +29,14 @@ module Lighthouse
         return @chrome_flags unless @chrome_flags.is_a?(Array)
 
         @chrome_flags.map { |f| "--#{f}" }.join(' ')
+      end
+
+      def results_directory
+        @results_directory ||= if defined?(RSpec)
+                                 File.join(RSpec.configuration.default_path, 'lighthouse')
+                               else
+                                 Dir.mktmpdir('lighthouse-matchers-')
+                               end
       end
 
       private

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -4,28 +4,35 @@ require 'rspec/expectations'
 require 'lighthouse/matchers'
 require 'lighthouse/audit_service'
 require 'json'
+require 'digest'
+require 'fileutils'
 
-RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
+RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}| # rubocop:disable Metrics/BlockLength
   score ||= args.fetch(:score, Lighthouse::Matchers.minimum_score)
 
   match do |target|
-    audit_service = AuditService.new(url(target), audit, score)
+    @audit_service = AuditService.new(url(target), audit, score)
 
-    audit_service.run_warnings.each do |warning|
+    @audit_service.run_warnings.each do |warning|
       RSpec.configuration.reporter.message(
         "#{RSpec.current_example.full_description}: [lighthouse] #{warning}"
       )
     end
 
-    @measured_score = audit_service.measured_score
+    @measured_score = @audit_service.measured_score
 
-    audit_service.passing_score?
+    @audit_service.passing_score?
   end
 
   failure_message do |target|
     <<~FAIL
       expected #{url(target)} to pass Lighthouse #{audit} audit
       with a minimum score of #{score}, but only scored #{@measured_score.to_i}
+
+      Full report:
+       #{save_audit_results}
+
+       To view this report, load this file into https://googlechrome.github.io/lighthouse/viewer/
     FAIL
   end
 
@@ -33,5 +40,16 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
 
   def url(target)
     target.respond_to?(:current_url) ? target.current_url : target
+  end
+
+  def save_audit_results
+    body = JSON.pretty_generate(@audit_service.results)
+
+    path = File.join(Lighthouse::Matchers.results_directory, "#{Digest::SHA1.hexdigest(body)}.json")
+
+    FileUtils.mkdir_p(Lighthouse::Matchers.results_directory)
+    File.write(path, body)
+
+    path
   end
 end


### PR DESCRIPTION
Pulled from #32, this should make it easier to understand why a failure happened and can be especially useful when there's inconsistent results.

I was hoping to have something similar to Capybara failure screenshots in Rails apps (which end up in/named e.g. `failures_r_spec_example_groups_homepage_passes_a_lighthouse_accessibility_audit_808`) but it turns out that is a Rails feature that seems to involve capturing the example name (or `method_name`, as its called by their code) separately when the suite starts, and while we look to have access to that in `matchers.rb` it just felt best to start simple.

That is also why for now I've not had the results directory use `Rails.root.join(...)` by default, though that will probably be the next thing I add

Closes #32