### PR TITLE
fix: prefix warning messages with full example description

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Prefix warnings with the full example description ([#69](https://github.com/ackama/lighthouse-matchers/pull/69))
 
 ## [1.2.0] - 2024-07-13
 ### Changed

--- a/lib/lighthouse/matchers/rspec.rb
+++ b/lib/lighthouse/matchers/rspec.rb
@@ -13,7 +13,7 @@ RSpec::Matchers.define :pass_lighthouse_audit do |audit, args = {}|
 
     audit_service.run_warnings.each do |warning|
       RSpec.configuration.reporter.message(
-        "#{RSpec.current_example.location}: [lighthouse] #{warning}"
+        "#{RSpec.current_example.full_description}: [lighthouse] #{warning}"
       )
     end
 


### PR DESCRIPTION
`RSpec.current_example.location` is focused on just the example, so if you're using a shared example you'll just get the shared example name e.g.

```
......................................................................F............................../spec/support/shared_examples/an_accessible_page.rb:6: [lighthouse] The page loaded too slowly to finish within the time limit. Results may be incomplete.
..................F.....F..F.....F
```

`full_description` however will give you the full example description which should make it easier to know what test generated the warning e.g.

```
Accessibility /users/unlock/new behaves like an accessible page passes a Lighthouse accessibility audit
```

While not as immediately usable as the file path, I still think it's better and I couldn't find a better alternative (at least without requiring `Rails`)